### PR TITLE
Don't update door/motion/dusk sensors when state has not changed

### DIFF
--- a/devices/device.py
+++ b/devices/device.py
@@ -97,8 +97,9 @@ class Device():
             'BatteryLevel': message.get_battery_level() or device.BatteryLevel,
             'SignalLevel': message.get_signal_level() or device.SignalLevel,
         }, **self.get_device_args(value, device, message))
-
-        device.Update(**device_values)
+        
+        if device.sValue != self.get_string_value(value, device):
+            device.Update(**device_values)
 
     def handle_command(self, device_data, command, level, color):
         device_address = device_data['ieee_addr']

--- a/devices/device.py
+++ b/devices/device.py
@@ -98,7 +98,7 @@ class Device():
             'SignalLevel': message.get_signal_level() or device.SignalLevel,
         }, **self.get_device_args(value, device, message))
         
-        if device.sValue != self.get_string_value(value, device):
+        if device.sValue != self.get_string_value(value, device) and device.SwitchType not in [2, 8, 11, 12]:
             device.Update(**device_values)
 
     def handle_command(self, device_data, command, level, color):

--- a/devices/device.py
+++ b/devices/device.py
@@ -98,7 +98,9 @@ class Device():
             'SignalLevel': message.get_signal_level() or device.SignalLevel,
         }, **self.get_device_args(value, device, message))
         
-        if device.sValue != self.get_string_value(value, device) and device.SwitchType not in [2, 8, 11, 12]:
+        if device.SwitchType in [2, 8, 11, 12]:
+            if device.sValue != self.get_string_value(value, device): device.Update(**device_values)
+        else:
             device.Update(**device_values)
 
     def handle_command(self, device_data, command, level, color):


### PR DESCRIPTION
This small modification blocks updates of door/motion/dusk sensors when their state has not really changed. This enables using the "otherdevices_lastupdate" attribute in LUa scripts to determine the (real) last status update. With the original implementation, sensors were sometimes updated (with the same state) just because their battery or signal status had changed.