### PR TITLE
Reversed behavior, now in line with other water leak sensors

### DIFF
--- a/devices/sensor/water_leak.py
+++ b/devices/sensor/water_leak.py
@@ -6,4 +6,4 @@ class WaterLeakSensor(BooleanSensor):
         super().__init__(devices, alias, value_key, BooleanSensor.SENSOR_TYPE_CONTACT)
 
     def get_numeric_value(self, value, device):
-        return 0 if value else 1
+        return 1 if value else 0


### PR DESCRIPTION
Reversed behavior, "open" or "on" now means: water detected, "closed" or " off" means: no water detected.
This is in line with other (e.g. Z-Wave) water leak sensors.
In this way, the icon turns "on" (e.g. red) when water is detected, which is more logical.