### PR TITLE
Add support for NET2GRID N2G-SP

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -7,6 +7,7 @@ from adapters.rgb_adapter import RGBAdapter
 from adapters.rgbw_adapter import RGBWAdapter
 from adapters.generic.motion_sensor import MotionSensorAdapter
 from adapters.generic.motion_temp_sensor import MotionAndTemperatureSensorAdapter
+from adapters.generic.on_off_kwh import OnOffKwhAdapter
 from adapters.generic.smoke_sensor import SmokeSensorAdapter
 from adapters.generic.temperature_sensor import TemperatureSensorAdapter
 from adapters.generic.water_leak_sensor import WaterLeakSensorAdapter
@@ -142,6 +143,8 @@ adapter_by_model = {
     '404006/404008/404004': DimmableCtBulbAdapter,  # Müller Licht Tint LED bulb GU10/E14/E27 350/470/806 lumen, dimmable, opal white
     # Nanoleaf
     'NL08-0800': DimmableBulbAdapter,   # Nanoleaf Ivy smart bulb
+    # NET2GRID
+    'N2G-SP': OnOffKwhAdapter,          # NET2GRID N2G-SP
     # Nue
     'FB56+ZSW05HG1.2': OnOffSwitchAdapter,      # Nue ZigBee one gang smart switch
     'HGZB-01A': DimmableBulbAdapter,    # Nue ZigBee smart light controller

--- a/adapters/generic/on_off_kwh.py
+++ b/adapters/generic/on_off_kwh.py
@@ -1,11 +1,9 @@
 from adapters.on_off_switch_adapter import OnOffSwitchAdapter
-from devices.sensor.voltage import VoltageSensor
 from devices.sensor.kwh import KwhSensor
 
 
-class Plug(OnOffSwitchAdapter):
+class OnOffKwhAdapter(OnOffSwitchAdapter):
     def __init__(self, devices):
         super().__init__(devices)
-        self.devices.append(VoltageSensor(devices, 'volt', 'voltage'))
-        values = ['power']
+        values = ['power', 'energy']
         self.devices.append(KwhSensor(devices, 'kwh', values))

--- a/devices/sensor/kwh.py
+++ b/devices/sensor/kwh.py
@@ -3,14 +3,30 @@ from devices.device import Device
 
 
 class KwhSensor(Device):
+    def __init__(self, devices, alias, value_key, device_name_suffix=''):
+        super().__init__(devices, alias, ';'.join(value_key), device_name_suffix)
+        self.value_keys = value_key
+    
     def create_device(self, unit, device_id, device_name):
         options = {}
         options['EnergyMeterMode'] = '1'
 
         return Domoticz.Device(Unit=unit, DeviceID=device_id, Name=device_name, TypeName="kWh", Options=options).Create()
 
+    def get_message_value(self, message):
+        value = {}
+
+        for item in self.value_keys:
+            if item in message.raw:
+                value[item] = message.raw[item]
+
+        return value if len(value) > 0 else None
+
     def get_numeric_value(self, value, device):
         return 0
 
     def get_string_value(self, value, device):
-        return str(value)
+        if 'energy' in value:
+            return str(value['power']) + ";" + str(value['energy'] * 1000)
+        else:
+            return str(value['power'])


### PR DESCRIPTION
This adds support for NET2GRID N2G-SP, which is an on/off switch
with power and energy measurement. This adds a new feature to do energy measurement.

This device will be added to zigbee2mqtt as part of https://github.com/Koenkk/zigbee-shepherd-converters/pull/381

I tested this with the NET2GRID N2G-SP device. I don't have the other device that does only power measurement (Xiaomi Aqara socket Zigbee), so I couldn't test with that.