### PR TITLE
Add support for SWO-KEF1PA

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -31,6 +31,7 @@ from adapters.samsung.sensor_arrival import SensorArrival
 from adapters.samsung.sensor_door import SmartThingsDoorSensor
 from adapters.philips.hue_dimmer_switch import HueDimmerSwitch
 from adapters.philips.hue_motion_sensor import HueMotionSensor
+from adapters.swo.KEF1PA import KEF1PA
 
 adapter_by_model = {
     # AduroSmart
@@ -241,6 +242,8 @@ adapter_by_model = {
     '74283': DimmableBulbAdapter,       # Sylvania LIGHTIFY LED soft white dimmable A19
     '74696': DimmableBulbAdapter,       # Sylvania LIGHTIFY LED soft white dimmable A19
     'LTFY004': RGBAdapter,              # Sylvania LIGHTIFY LED gardenspot mini RGB
+    # Swann One
+    'SWO-KEF1PA': KEF1PA,					# Swann Key fob remote (panic, home, away, sleep)
     # Trust
     'ZLED-2709': DimmableBulbAdapter,   # Trust Smart Dimmable LED Bulb
     'ZPIR-8000': MotionSensorAdapter,   # Trust Motion Sensor

--- a/adapters/swo/KEF1PA.py
+++ b/adapters/swo/KEF1PA.py
@@ -1,0 +1,18 @@
+from adapters.adapter_with_battery import AdapterWithBattery
+from devices.switch.selector_switch import SelectorSwitch
+
+class KEF1PA(AdapterWithBattery):
+    def __init__(self, devices):
+        super().__init__(devices)
+
+        self.switch = SelectorSwitch(devices, 'KEF1PA', 'action')
+        self.switch.add_level('Off', None)
+        self.switch.add_level('Panic', 'panic')
+        self.switch.add_level('Home', 'home')
+        self.switch.add_level('Away', 'away')
+        self.switch.add_level('Sleep', 'sleep')
+        self.switch.set_selector_style(SelectorSwitch.SELECTOR_TYPE_MENU)
+        self.devices.append(self.switch)
+
+    def handleCommand(self, alias, device, device_data, command, level, color):
+        self.switch.handle_command(device_data, command, level, color)


### PR DESCRIPTION
Add support for the Swann One key fob remote (4 buttons: panic, home, away, sleep)
Will create a Selector Switch in Domoticz, can be used with a lua script to control the security panel, or anything else.
Not sure if a 'voltage' message will be issued when the battery is low, but so far nothing sent by the remote.

**MQTT message with device information**
```
{"ieeeAddr":"0x00124b000610d7d0","type":"EndDevice","model":"SWO-KEF1PA","friendly_name":"Swann_Keychain","nwkAddr":28300,"manufId":0,"manufName":"SwannONe","powerSource":"Battery","modelId":"SWO-KEF1PA","hwVersion":1,"dateCode":"20150306        "}
```

**MQTT messages from device**
```
zigbee2mqtt:info 5/11/2019, 2:45:06 PM MQTT publish: topic 'zigbee2mqtt/Swann_Keychain', payload '{"linkquality":26,"action":"panic"}'

zigbee2mqtt:info 5/11/2019, 2:45:09 PM MQTT publish: topic 'zigbee2mqtt/Swann_Keychain', payload '{"linkquality":47,"action":"home"}'

zigbee2mqtt:info 5/11/2019, 2:45:10 PM MQTT publish: topic 'zigbee2mqtt/Swann_Keychain', payload '{"linkquality":28,"action":"away"}'

zigbee2mqtt:info 5/11/2019, 2:45:13 PM MQTT publish: topic 'zigbee2mqtt/Swann_Keychain', payload '{"linkquality":31,"action":"sleep"}'
```