### PR TITLE
added support for ptvo firmware on cc2530 ZigBee adapter (DIY inputs and outputs)

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -46,6 +46,7 @@ from adapters.philips.hue_dimmer_switch import HueDimmerSwitch
 from adapters.philips.hue_motion_sensor import HueMotionSensor
 from adapters.swo.KEF1PA import KEF1PA
 from adapters.thermostat import ThermostatAdapter
+from adapters.diy.ptvo_switch import PtvoSwitch
 
 adapter_by_model = {
     # AduroSmart
@@ -337,5 +338,7 @@ adapter_by_model = {
     # ilux
     '900008-WW': DimmableBulbAdapter,    # ilux Dimmable A60 E27 LED Bulb
     # Eurotronic
-    'SPZB0001': ThermostatAdapter       # SPZB0001 thermostat
+    'SPZB0001': ThermostatAdapter,       # SPZB0001 thermostat
+    # Unbranded DIY adapters
+    'ptvo.switch': PtvoSwitch            # cc2530 zigbee module with pvto.switch firmware (buttons only for now!)
 }

--- a/adapters/diy/ptvo_switch.py
+++ b/adapters/diy/ptvo_switch.py
@@ -1,0 +1,28 @@
+# Adapter for cc2530 zigbee firmware found on http://ptvo.info/zigbee-switch-configurable-firmware-router-199/
+
+from adapters.base_adapter import Adapter
+from adapters.on_off_switch_adapter import OnOffSwitchAdapter
+from devices.text_sensor import TextSensor
+from devices.switch.on_off_switch import OnOffSwitch
+
+PTVOID = {'input1' : 'bottom_left',
+		  'input2' : 'bottom_right',
+		  'input3' : 'top_left',
+		  'input4' : 'top_right',
+          'input5' : 'center'}
+
+class PtvoSwitch(Adapter):
+    def __init__(self, devices):
+        super().__init__(devices)
+        self.devices.append(TextSensor(devices, 'click', 'click', ' (input)'))
+        self.switch={}
+        for ptvo in PTVOID:
+            self.switch[ptvo] = OnOffSwitch(devices, ptvo, 'state_' + ptvo, ' (' + ptvo + ')')
+            self.devices.append(self.switch[ptvo])
+
+    def handleCommand(self, alias, device, device_data, command, level, color):
+        self.switch[alias].handle_command(device_data, command, level, color)
+        return {
+            'topic': '/'.join([device_data['friendly_name'], PTVOID[alias], 'set']),
+            'payload': command.upper()
+        }

--- a/adapters/on_off_switch_adapter.py
+++ b/adapters/on_off_switch_adapter.py
@@ -6,7 +6,6 @@ from devices.switch.on_off_switch import OnOffSwitch
 class OnOffSwitchAdapter(Adapter):
     def __init__(self, devices):
         super().__init__(devices)
-
         self.switch = OnOffSwitch(devices, 'switch', 'state')
         self.devices.append(self.switch)
 

--- a/devices/text_sensor.py
+++ b/devices/text_sensor.py
@@ -1,0 +1,13 @@
+import Domoticz
+from devices.device import Device
+
+class TextSensor(Device):
+    def create_device(self, unit, device_id, device_name):
+        return Domoticz.Device(Unit=unit, DeviceID=device_id, Name=device_name, TypeName="Text").Create()
+
+    def get_numeric_value(self, value, device):
+        #Work-around, because a text sensor had no numeric value
+        return 0
+
+    def get_string_value(self, value, device):
+        return str(value)


### PR DESCRIPTION
Also added a text_sensor device, so no unnecessary devices or selector options will be created. The number of inputs (and their behavior) on the ptvo firmware is configurable.
Supports both:
- Inputs (every type of input goes to the same text sensor and can be used in scripts)
- Outputs (a domoticz switch is created for each of the maximum 5 inputs, whether they are configured in the firmware or not)

I am not going to use it myself, but saw the feature request and had the cc2530 laying around and was intrigued ;-) It's up to real users of the ptvo firmware to further enhance or maintain.

@stas-demydiuk : pleas check if the text_sensor is acceptable as a new type of device. I think It will be really useful. I would have also used it for the hue remote control, had it been available then. 