### PR TITLE
handle status update_failed

### DIFF
--- a/api/devices.py
+++ b/api/devices.py
@@ -51,7 +51,7 @@ class GetDeviceOTAUpdateStatus(APICommand):
             if meta['status'] == 'available':
                 self.send_response(message['message'])
 
-            if meta['status'] == 'not_available' or meta['status'] == 'check_failed' or meta['status'] == 'not_supported':
+            if meta['status'] == 'not_available' or meta['status'] == 'check_failed' or meta['status'] == 'not_supported' or meta['status'] == 'update_failed':
                 self.send_error(message['message'])
 
 


### PR DESCRIPTION
The bridge (or zigbee device?) can also report the status 'update_failed' as meta. This is now not handled. I ran across this several days ago, fetch this out of my log file. Unfortunately while testing this update, the update just worked flawlessly. However I'm pretty sure this addition will work. See below loglines I based this change on.

2020-04-18 14:19:37.241  (Zigbee2MQTT) API handle request: {"type":"request","requestId":9,"command":"ota_update","params":{"topic":"/bridge/ota_update/update","state":"Bamboe lamp 1"}}
2020-04-18 14:19:37.241  (Zigbee2MQTT) New request: [9] ota_update({"topic": "/bridge/ota_update/update", "state": "Bamboe lamp 1"})
2020-04-18 14:19:37.242  (Zigbee2MQTT) API OTACommand for: params = '{'topic': '/bridge/ota_update/update', 'state': 'Bamboe lamp 1'}' self.request_id = '9'
2020-04-18 14:19:37.242  (Zigbee2MQTT) MqttClient::publish zigbee2mqtt/bridge/ota_update/update (Bamboe lamp 1)
2020-04-18 14:19:37.319  (Zigbee2MQTT) MQTT message: zigbee2mqtt/bridge/ota_update/update Bamboe lamp 1
2020-04-18 14:19:37.319  (Zigbee2MQTT) API handle mqtt message: Bamboe lamp 1
2020-04-18 14:19:37.319  (Zigbee2MQTT) Unhandled message from zigbee2mqtt: bridge/ota_update/update Bamboe lamp 1
2020-04-18 14:19:37.319  (Zigbee2MQTT) MQTT message: zigbee2mqtt/bridge/log {'type': 'ota_update', 'message': "Updating 'Bamboe lamp 1' to latest firmware", 'meta': {'status': 'update_in_progress', 'device': 'Bamboe lamp 1'}}
2020-04-18 14:19:37.320  (Zigbee2MQTT) API handle mqtt message: {'type': 'ota_update', 'message': "Updating 'Bamboe lamp 1' to latest firmware", 'meta': {'status': 'update_in_progress', 'device': 'Bamboe lamp 1'}}
2020-04-18 14:19:37.320  (Zigbee2MQTT) OverTheAir update status: "Updating 'Bamboe lamp 1' to latest firmware"
2020-04-18 14:19:37.971  (Zigbee2MQTT) MQTT message: zigbee2mqtt/bridge/log {'type': 'ota_update', 'message': "Update of 'Bamboe lamp 1' failed (No new image available)", 'meta': {'status': 'update_failed', 'device': 'Bamboe lamp 1'}}
2020-04-18 14:19:37.972  (Zigbee2MQTT) API handle mqtt message: {'type': 'ota_update', 'message': "Update of 'Bamboe lamp 1' failed (No new image available)", 'meta': {'status': 'update_failed', 'device': 'Bamboe lamp 1'}}
2020-04-18 14:19:37.972  (Zigbee2MQTT) OverTheAir update status: "Update of 'Bamboe lamp 1' failed (No new image available)"
