### PR TITLE
Use os.makedirs to create install dirs

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -178,7 +178,7 @@ class BasePlugin:
             Domoticz.Debug('Copying files from ' + source_path + ' to ' + templates_path)
 
             if not (os.path.isdir(dst_plugin_path)):
-                os.mkdir(dst_plugin_path)
+                os.makedirs(dst_plugin_path)
 
             copy2(source_path + '/zigbee2mqtt.html', templates_path)
             copy2(source_path + '/zigbee2mqtt.js', templates_path)


### PR DESCRIPTION
If the parent dirs do not exist during install of this plugin, `os.mkdir` in `BasePlugin.install()` fails with the following message:
```
2020-05-28 06:38:34.329  Error: (Zigbee2MQTT HW) Error during installing plugin custom page
2020-05-28 06:38:34.329  Error: (Zigbee2MQTT HW) FileNotFoundError(2, 'No such file or directory'
```
This can happen if domoticz's userdata is configured to be a blank new directory via the `--userdata` flag.