### PR TITLE
Update ptvo_switch.py

### DIFF
--- a/adapters/diy/ptvo_switch.py
+++ b/adapters/diy/ptvo_switch.py
@@ -5,11 +5,14 @@ from adapters.on_off_switch_adapter import OnOffSwitchAdapter
 from devices.text_sensor import TextSensor
 from devices.switch.on_off_switch import OnOffSwitch
 
-PTVOID = {'input1' : 'bottom_left',
-		  'input2' : 'bottom_right',
-		  'input3' : 'top_left',
-		  'input4' : 'top_right',
-          'input5' : 'center'}
+#PTVOID = {'input1' : 'bottom_left',
+#		  'input2' : 'bottom_right',
+#		  'input3' : 'top_left',
+#		  'input4' : 'top_right',
+#         'input5' : 'center'}
+
+#update to latest zigbee2MQTT 1.14.3 compatible
+PTVOID = {'input1' : 'I1', 'input2' : 'I2', 'input3' : 'I3', 'input4' : 'I4', 'input5' : 'I5'}
 
 class PtvoSwitch(Adapter):
     def __init__(self, devices):

--- a/adapters/diy/ptvo_switch.py
+++ b/adapters/diy/ptvo_switch.py
@@ -12,7 +12,7 @@ from devices.switch.on_off_switch import OnOffSwitch
 #         'input5' : 'center'}
 
 #update to latest zigbee2MQTT 1.14.3 compatible
-PTVOID = {'input1' : 'I1', 'input2' : 'I2', 'input3' : 'I3', 'input4' : 'I4', 'input5' : 'I5'}
+PTVOID = {'input1' : 'l1', 'input2' : 'l2', 'input3' : 'l3', 'input4' : 'l4', 'input5' : 'l5'}
 
 class PtvoSwitch(Adapter):
     def __init__(self, devices):


### PR DESCRIPTION
Update to latest Zigbee2Mqtt release compatible 1.14.3. Old "PTVOID" doesn't work anymore (Bottom_Left...etc)

Error log:
`Zigbee2MQTT:error 2020-08-16 09:49:19: Failed to call ‘EntityPublish’ ‘onMQTTMessage’ (AssertionError [ERR_ASSERTION]: Endpoint name ‘bottom_left’ is given but device has no such endpoint`