### PR TITLE
Added Silvercrest (Lidl) HG06336 Window/Door Sensor

### DIFF
--- a/adapters/__init__.py
+++ b/adapters/__init__.py
@@ -37,6 +37,7 @@ from adapters.oujiabao.CR701_YZ import CR701_YZ
 from adapters.siterwell.GS361AH04 import GS361AH04
 from adapters.samsung import samsung_adapters
 from adapters.schneider_electric import schneider_adapters
+from adapters.silvercrest import silvercrest_adapters
 from adapters.sinope import sinope_adapters
 from adapters.sonoff import sonoff_adapters
 from adapters.philips import philips_adapters
@@ -213,6 +214,7 @@ adapter_by_model = dict({
     **philips_adapters,
     **samsung_adapters,
     **schneider_adapters,
+    **silvercrest_adapters,
     **sinope_adapters,
     **sonoff_adapters,
     **trust_adapters,

--- a/adapters/silvercrest/HG06336.py
+++ b/adapters/silvercrest/HG06336.py
@@ -1,0 +1,10 @@
+from adapters.adapter_with_battery import AdapterWithBattery
+from devices.sensor.door_contact import DoorContactSensor
+from devices.sensor.contact import ContactSensor
+
+
+class HG06336(AdapterWithBattery):
+    def __init__(self, devices):
+        super().__init__(devices)
+        self.devices.append(DoorContactSensor(devices, 'sensor', 'contact'))
+        self.devices.append(ContactSensor(devices, 'tamper', 'tamper'))

--- a/adapters/silvercrest/__init__.py
+++ b/adapters/silvercrest/__init__.py
@@ -1,0 +1,17 @@
+from adapters.on_off_switch_adapter import OnOffSwitchAdapter
+from adapters.contact_adapter import ContactAdapter
+from devices.sensor.door_contact import DoorContactSensor
+from adapters.generic.motion_sensor import MotionSensorAdapter
+from adapters.dimmable_bulb_adapter import DimmableBulbAdapter
+from adapters.dimmable_ct_bulb_adapter import DimmableCtBulbAdapter
+from adapters.rgbw_adapter import RGBWAdapter
+from adapters.silvercrest.HG06336 import HG06336
+
+
+
+silvercrest_adapters = {
+    'TY0202': MotionSensorAdapter,      # Silvercrest Smart Window or Door sensor
+    'TY0203': ContactAdapter,           # Silvercrest Smart Window or Door sensor
+    'HG06336':HG06336,                  # Silvercrest Smart Window or Door sensor
+    'TY0111': OnOffSwitchAdapter,       # Silvercrest Smart Home Socket
+}


### PR DESCRIPTION
Rudimentary addition of the new Silvercrest (Lidl) HG06336 Contact Sensor. Including working Tamper switch.

Could use some code cleanup, but decided not to mess to much with the original files since it is my first addition to your Plugin and i left some space open to add other Silvercrest sensors into it.