### PR TITLE
Add temperature for MCCGQ11LM door/window sensor

### DIFF
--- a/adapters/lumi/MCCGQ11LM.py
+++ b/adapters/lumi/MCCGQ11LM.py
@@ -1,0 +1,9 @@
+from adapters.adapter_with_battery import AdapterWithBattery
+from devices.sensor.door_contact import DoorContactSensor
+from devices.sensor.temperature import TemperatureSensor
+
+class MCCGQ11LM(AdapterWithBattery):
+    def __init__(self, devices):
+        super().__init__(devices)
+        self.devices.append(DoorContactSensor(devices, 'sensor', 'contact'))
+        self.devices.append(TemperatureSensor(devices, 'temp', 'temperature', 'temperature'))

--- a/adapters/lumi/__init__.py
+++ b/adapters/lumi/__init__.py
@@ -17,6 +17,7 @@ from adapters.lumi.WXCJKG11LM import WXCJKG11LM
 from adapters.lumi.WXCJKG12LM import WXCJKG12LM
 from adapters.lumi.WXCJKG13LM import WXCJKG13LM
 from adapters.lumi.LLKZMK11LM import LLKZMK11LM
+from adapters.lumi.MCCGQ11LM import MCCGQ11LM
 
 
 lumi_adapters = {
@@ -26,7 +27,7 @@ lumi_adapters = {
     'JTYJ-GD-01LM/BW': JTYJ_GD_01LM,    # Xiaomi MiJia Honeywell smoke detector
     'JTQJ-BF-01LM/BW': GasSensorAdapter,    # Xiaomi MiJia gas leak detector
     'MCCGQ01LM': SensorMagnet,          # Xiaomi MiJia door & window contact sensor
-    'MCCGQ11LM': SensorMagnet,          # Xiaomi Aqara door & window contact sensor
+    'MCCGQ11LM': MCCGQ11LM,          	# Xiaomi Aqara door & window contact with temperature sensor
     'MFKZQ01LM': SensorCube,            # Xiaomi Mi smart home cube
     'RTCGQ01LM': MotionSensorAdapter,   # Xiaomi MiJia human body movement sensor
     'RTCGQ11LM': SensorMotionAq2,       # Xiaomi Aqara human body movement and illuminance sensor


### PR DESCRIPTION
... and not to the older door/window sensor model
Replaces pull request #562!

Note that the temperature reading is nog very accurate. The temperature_calibration setting can compensate for the higher reading, but not for the slow/limited response to temperature changes. I suspect the response is probably limited by the enclosure of the door/window sensor and it was never really intended to be used as a temperature sensor. Still a nice feature that offers a usable indication of temperature changes.