### PR TITLE
HS1RC alarm remote - disable_value_check_on_update

### DIFF
--- a/adapters/heiman/HS1RC.py
+++ b/adapters/heiman/HS1RC.py
@@ -12,6 +12,7 @@ class HeimanAlarmRemoteAdapter(AdapterWithBattery):
         self.switch.add_level('Disarm', 'disarm')
         self.switch.add_level('Emergency', 'emergency')
         self.switch.set_selector_style(SelectorSwitch.SELECTOR_TYPE_MENU)
+        self.switch.disable_value_check_on_update()
         self.devices.append(self.switch)
 
     def convert_message(self, message):


### PR DESCRIPTION
... so repeated keypresses on the remote still trigger scripts

(Cleaned up my GitHub fork and resubmitted this pr because the previous one was a mess ... apologies for that. I have now learned not to edit the master of my fork :-$)