### PR TITLE
Fix creation of Hive SLR2 features

### DIFF
--- a/devices/device.py
+++ b/devices/device.py
@@ -50,9 +50,11 @@ class Device():
 
         device_id = device_address
 
-        if self.device_name_suffix != '':
+        if self.device_name_suffix != self.value_key:
+            device_name = device_data['friendly_name'] + ' (' + self.value_key + ')'
+        elif self.device_name_suffix != '':
             device_name = device_data['friendly_name'] + self.device_name_suffix
-        elif hasattr(self, 'feature'):
+        elif hasattr(self, 'property'):
             device_name = device_data['friendly_name'] + ' (' + self.feature['property'] + ')'
         else:
             device_name = device_data['friendly_name']
@@ -66,7 +68,7 @@ class Device():
             return None
 
         if unit == None:
-            domoticz.error('Can not create new Domoticz device: maximum of 255 logical devices per phisical is reached.')
+            domoticz.error('Can not create new Domoticz device: maximum of 255 logical devices per physical is reached.')
             return None
 
         device = self.create_device(unit, device_id, device_name)
@@ -119,10 +121,10 @@ class Device():
 
         if device != None:
             return
-        
+
         # Try to find legacy device from plugin < 4.x version with device id "address_alias"
         device = self.get_legacy_device(device_address, self.alias)
-        
+ 
         if device != None:
             feature_name = self._get_feature_name()
             device_id = device_address + '_' + self.alias
@@ -182,7 +184,7 @@ class Device():
             'BatteryLevel': message.get_battery_level() or device.BatteryLevel,
             'SignalLevel': message.get_signal_level() or device.SignalLevel,
         }, **self.get_device_args(value, device, message))
-        
+
         self.update_device(device, device_values)
 
     def handle_command(self, device_data, command, level, color):


### PR DESCRIPTION
Addresses issues when Hive SLR2 controller features are created, as documented in Bug #719:

1. `adapter.py`: Binary device `temperature_setpoint_hold` doesn't get created and generates an error, so add in defintion of this feature.
2. `adapter.py`: Creation of setpoint numeric features assumes they have a `unit` attribute which Hive `temperature_setpoint_hold_duration` feature does not have (`unit` attribute is not present) - this causes no features to be added for **all** devices after this point as the plugin abends, so add a `try/except` check to see if we can access the `unit` feature and if not create a `CustomSensor` not a `SetPoint`.
3. `devices\devices.py`: Hive SLR2 has `heat` and `water` endpoints but currently `devices.py` creates a pair of features with the same names (so `temperature_setpoint_hold_heat` and `temperature_setpoint_hold_water` both get created as `temperature_setpoint_hold` so we cannot differentiate which feature is for which endpoint) - add in an option to create the feature suffix using `self.value_key` which then creates these with the full feature name.