### PR TITLE
Force counter to zero for power only kWh sensor

### DIFF
--- a/devices/sensor/kwh.py
+++ b/devices/sensor/kwh.py
@@ -32,4 +32,4 @@ class KwhSensor(Device):
         if len(value) == 2:
             return str(value[0]) + ";" + str(int(value[1] * self.energy_multiplier))
         else:
-            return str(value[0])
+            return str(value[0]) + ";0"


### PR DESCRIPTION
Domoticz requires a two values sValue with power and energy.. This change forces counter to zero on power only counter (without energy)